### PR TITLE
remove inbound firewall rule from vib

### DIFF
--- a/firewall/stage/payloads/payload1/etc/vmware/firewall/drpcli.xml
+++ b/firewall/stage/payloads/payload1/etc/vmware/firewall/drpcli.xml
@@ -13,20 +13,8 @@
     </service>
 
     <service>
-        <id>drpcli-in</id>
-        <rule id='0001'>
-            <direction>inbound</direction>
-            <protocol>tcp</protocol>
-            <porttype>dst</porttype>
-            <port>8092</port>
-        </rule>
-        <enabled>true</enabled>
-        <required>false</required>
-    </service>
-
-    <service>
         <id>drp-fs-out</id>
-        <rule id="0002">
+        <rule id="0001">
             <direction>outbound</direction>
             <protocol>tcp</protocol>
             <porttype>dst</porttype>


### PR DESCRIPTION
Removed inbound firewall rule for 8092 from firewall vib

Signed-off-by: Michael Rice <michael@michaelrice.org>