### PR TITLE
fix(agent,action_runner,client,base,waitrunnable) Fixes stack issue from failed get machine

### DIFF
--- a/drpy/bin/agent
+++ b/drpy/bin/agent
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 from drpy.cli import cli
 from drpy.models import config
 from drpy.api.client import Client
@@ -25,6 +28,13 @@ def main():
         wait=False,
         runner=runner
     )
+    if agent_state.config.command_path == '' or \
+            agent_state.config.command_path is None:
+        path = "/opt/rackn/runner"
+    else:
+        path = agent_state.config.command_path
+    if os.path.exists(path):
+        shutil.rmtree(path)
     machine_state = Initialize()
     while machine_state.state != "Exit":
         machine_state, agent_state = machine_state.on_event(

--- a/drpy/src/drpy/action_runner.py
+++ b/drpy/src/drpy/action_runner.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 from drpy.exceptions import DRPException
@@ -30,6 +31,8 @@ def run_command(job_action=None, timeout=None, expath=None):
         path = "/opt/rackn/runner"
     if path.endswith("/"):
         path = path[:-1]
+    if os.path.exists(path):
+        shutil.rmtree(path)
     os.makedirs(path, exist_ok=True)
     file = path + "/{}".format(job_action.Name)
     with open(file, 'x') as f:

--- a/drpy/src/drpy/api/client.py
+++ b/drpy/src/drpy/api/client.py
@@ -116,7 +116,7 @@ class Client:
                 data = res.read().decode('utf-8')
                 json_obj = json.loads(data)
                 return json_obj
-            except urllib.error.URLError as e:
+            except (urllib.error.URLError, RemoteDisconnected) as e:
                 time.sleep(5)
                 retry_count = retry_count + 1
                 saved_error = e


### PR DESCRIPTION
Fixing stack trace when the machine object was not returned from a get machines
Added cleanup to the runner dir on agent init and before tasks are run

Signed-off-by: Michael Rice <michael@michaelrice.org>