### PR TITLE
refactor: Added a filter to ensure only ESXi tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,30 +12,30 @@ install:
 script:
 - flake8
 - pytest -v -l --cov tests/
-after_success:
-- "./build.sh $TRAVIS_BUILD_DIR/drpy/stage/payloads/drpy/opt/rackn/drpy"
-- cd $TRAVIS_BUILD_DIR
-- ./build_tools/set_version.sh drpy/stage/descriptor.xml
-- ./build_tools/set_version.sh firewall/stage/descriptor.xml
-- docker pull lamw/vibauthor
-- docker run -d --name=vibauthor -v $TRAVIS_BUILD_DIR/drpy/stage:/root/drpy/stage
-  -v $TRAVIS_BUILD_DIR/firewall:/root/firewall lamw/vibauthor tail -f /dev/null
-- docker exec -it vibauthor /bin/bash -c "cd drpy/ && vibauthor -C -t stage -f"
-- mkdir -p $TRAVIS_BUILD_DIR/grd/vibs
-- cp $TRAVIS_BUILD_DIR/drpy/stage/*.vib $TRAVIS_BUILD_DIR/grd/vibs
-- docker exec -it vibauthor /bin/bash -c "cd firewall/ && vibauthor -C -t stage -f"
-- cp $TRAVIS_BUILD_DIR/firewall/stage/*.vib $TRAVIS_BUILD_DIR/grd/vibs
-deploy:
-  provider: s3
-  region: us-west-2
-  skip_cleanup: true
-  access_key_id: AKIAJF4QJY2A23DY6YTQ
-  secret_access_key:
-    secure: jvEP+fubu5OjwKOuo04T1llCBOIipa8DL0o0HqRkyn66QEe7nxCC8OBbJCI1y+3aWWDTar8B5J7Sx/MUXF7REricM5YCcUv8sl/a6nGStKLWAAGRAP0/Dd+4oH8g5ZT8mmlT3pngkbRkN86ZOe3zUws0rHpkxuXiKsO6d9x2936prRRDF8QGZjKF91mg+x6SjH+mYGQOtK3XuWHoBmtWqMTQzfQOfTbl1WrHi4+mRIq9bDbxGsU4Cto1nioAbEe0w8mvxsf/aUO/t6A/Xl40gp90PElFMO9jQP6FM+Yy4JXFQMxBiAv8XuJ81f4NuRgaxPrQIiCCDNmZ6OmRidgz78DrH06ZcbYO9SVynQ4SbTiFLGpv3U/F2N6z5wru7J4NUxTZCvcjnO6UnXg28URzw+DvdF3O93QOqBNXlSdDu2ITsoEOZCmUMyf+ZWMf7u9D71oEWx0zw7xVPEgVGzLRC/PDW8lV8vzOE6LgdZICQjhb7o8zA6uGWQIh/6zLIrZ2KPSAIBa20teDg9n8kaT+yjRdVEUQY3ptVpninuMRs6Etsh6L6mnPKM548d7XOvT7W1SVJ7dpniwZewa1eWSEjVoWn2msKXwNWCNCE0kQV5yGInuGs0cGf3LNvDIEwN668jhg9ypZBN7sVJWPKM9bo1/1F+vGSHOHxBqxWSAN8Ho=
-  bucket: get.rebar.digital
-  local-dir: grd
-  upload-dir: artifacts
-  acl: public_read
-  on:
-    repo: rackn/vmware_tools
-    tags: true
+#after_success:
+#- "./build.sh $TRAVIS_BUILD_DIR/drpy/stage/payloads/drpy/opt/rackn/drpy"
+#- cd $TRAVIS_BUILD_DIR
+#- ./build_tools/set_version.sh drpy/stage/descriptor.xml
+#- ./build_tools/set_version.sh firewall/stage/descriptor.xml
+#- docker pull lamw/vibauthor
+#- docker run -d --name=vibauthor -v $TRAVIS_BUILD_DIR/drpy/stage:/root/drpy/stage
+#  -v $TRAVIS_BUILD_DIR/firewall:/root/firewall lamw/vibauthor tail -f /dev/null
+#- docker exec -it vibauthor /bin/bash -c "cd drpy/ && vibauthor -C -t stage -f"
+#- mkdir -p $TRAVIS_BUILD_DIR/grd/vibs
+#- cp $TRAVIS_BUILD_DIR/drpy/stage/*.vib $TRAVIS_BUILD_DIR/grd/vibs
+#- docker exec -it vibauthor /bin/bash -c "cd firewall/ && vibauthor -C -t stage -f"
+#- cp $TRAVIS_BUILD_DIR/firewall/stage/*.vib $TRAVIS_BUILD_DIR/grd/vibs
+#deploy:
+#  provider: s3
+#  region: us-west-2
+#  skip_cleanup: true
+#  access_key_id: AKIAJF4QJY2A23DY6YTQ
+#  secret_access_key:
+#    secure: jvEP+fubu5OjwKOuo04T1llCBOIipa8DL0o0HqRkyn66QEe7nxCC8OBbJCI1y+3aWWDTar8B5J7Sx/MUXF7REricM5YCcUv8sl/a6nGStKLWAAGRAP0/Dd+4oH8g5ZT8mmlT3pngkbRkN86ZOe3zUws0rHpkxuXiKsO6d9x2936prRRDF8QGZjKF91mg+x6SjH+mYGQOtK3XuWHoBmtWqMTQzfQOfTbl1WrHi4+mRIq9bDbxGsU4Cto1nioAbEe0w8mvxsf/aUO/t6A/Xl40gp90PElFMO9jQP6FM+Yy4JXFQMxBiAv8XuJ81f4NuRgaxPrQIiCCDNmZ6OmRidgz78DrH06ZcbYO9SVynQ4SbTiFLGpv3U/F2N6z5wru7J4NUxTZCvcjnO6UnXg28URzw+DvdF3O93QOqBNXlSdDu2ITsoEOZCmUMyf+ZWMf7u9D71oEWx0zw7xVPEgVGzLRC/PDW8lV8vzOE6LgdZICQjhb7o8zA6uGWQIh/6zLIrZ2KPSAIBa20teDg9n8kaT+yjRdVEUQY3ptVpninuMRs6Etsh6L6mnPKM548d7XOvT7W1SVJ7dpniwZewa1eWSEjVoWn2msKXwNWCNCE0kQV5yGInuGs0cGf3LNvDIEwN668jhg9ypZBN7sVJWPKM9bo1/1F+vGSHOHxBqxWSAN8Ho=
+#  bucket: get.rebar.digital
+#  local-dir: grd
+#  upload-dir: artifacts
+#  acl: public_read
+#  on:
+#    repo: rackn/vmware_tools
+#    tags: true

--- a/drpy/README.rst
+++ b/drpy/README.rst
@@ -109,3 +109,45 @@ Example Config File
   endpoint = https://api.drp.local:8092/
   token = EdBk_k7R3S5Q5Prz6uxdahbFdjKQPG_GsWEv1SUfa1rnVy-BIYw6jJ5_qrQGpROfZuanTrqSf37kSOYXhVaMxzHV3RC5_7s9ysBUZRtTVJF2G72XqNDDqlbR9mVnjNxQEX8p1l8NoUZdQ6WbYAmlkDMEvZB22QfiybQNzy_-vceUdEyvsKEH1_Q2j4PIHzaYF-7ZlfqCOD3cIeeGZXQH2xhGTpOQyvidt2Z1Y2lKiAQyhuGLn0Tt119Ju9NSshkHwEhoLjCcM6L37yadMy8Q5EAiLmKra4FqIFE9VqxHJZWteYis1HyWs_0gTH7Arwi4pNovneSCN679SwUhz8OwSzLg9rtxeF2JDcIFDS7DgXZaKLV97wP8PFbn3yBU1VT38aWQvraUxnZYaO1kiCwBL24PC24mhXzsUk1I-8sJvlqOc18JfYymq7PbrMtwbAU1tzSLkQJWxGn5EA_9xo9wKW-_FjTQvlGukRQ7lCDhXD8Q2TGH33cpXEgvjfklQvtdrOKQ_sBU4WSht5dzUbjVs9NvNJJHyspwo3govV_4WrMUCrxjkNiC_rCBgtfw9uhmnkT35CTPVMU0MVKG3Mb2OfcI3Owwpdinuz_fipYsEuoyxXkPilUAc6VdJdFRX02oDfoBQS3FrmLkx0CcmPTuZ4r8SIPKn1tl7Za6Hpt3LCSlQlUc1-Iy6I_qUo5zBHGrySIYfWa3Y1Dkb2eV4Cadz0PnJmgbBTVFYDW0t8aLDoywOOsSUPLt6TlMfCcxHGhDdgJoVvbbaS7uymJjsjkHRYtJVlb0M3DJuVgntYjNRPxK7c5HqSD5SnyG2eVnpVH8-QLgPz_kOyJtW8Vl8nMP0zYEBpiitKgGx9e-JITzOo_-eKCJOUtO3dI=
   machine_uuid = e1dec675-9f43-40d6-b501-e4e481d66378
+
+  [loggers]
+  keys=root,drpy
+
+  [handlers]
+  keys=fileHandler,streamHandler
+
+  [formatters]
+  keys=drpyFormatter
+
+  [logger_root]
+  level=NOTSET
+  handlers=
+
+  [logger_drpy]
+  ; Set this to adjust
+  level=DEBUG
+  handlers=fileHandler,streamHandler
+  qualname=drpy
+
+  [handler_fileHandler]
+  class=FileHandler
+  ; Set the level here to change the level output into the file
+  ; debug at logger level and info here would result in info only
+  ; messages logged to the file.
+  ; Likewise if logger is set to info but file is set to debug
+  ; the logger is only putting out info level messages so thats
+  ; still all that will be captured.
+  level=DEBUG
+  args=('drpy.log', 'w')
+  formatter=drpyFormatter
+
+  [formatter_drpyFormatter]
+  format=RackN: %(asctime)s - %(name)s - %(levelname)s - %(message)s
+  datefmt=
+  class=logging.Formatter
+
+  [handler_streamHandler]
+  class=StreamHandler
+  level=DEBUG
+  args=(sys.stdout,)
+  formatter=drpyFormatter

--- a/drpy/bin/agent
+++ b/drpy/bin/agent
@@ -1,6 +1,9 @@
 import os
 import shutil
 
+from logging.config import fileConfig
+
+from drpy import logger
 from drpy.cli import cli
 from drpy.models import config
 from drpy.api.client import Client
@@ -18,6 +21,8 @@ def main():
     conf = config.parse(conf_file)
     runner = args.runner
 
+    fileConfig(conf_file)
+    logger.debug("Starting up agent")
     drpclient = Client(
         endpoint=conf.endpoint,
         token=conf.token
@@ -47,5 +52,5 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print("Exiting...")
+        logger.debug("Keyboard interrupt detected. Exiting...")
         raise SystemExit

--- a/drpy/src/drpy/fsm/states/runtask.py
+++ b/drpy/src/drpy/fsm/states/runtask.py
@@ -86,7 +86,7 @@ class RunTask(BaseState):
         return Job(**j_obj)
 
     def _get_job_actions(self, agent_state=None):
-        jr = "jobs/{}/actions".format(agent_state.job.Uuid)
+        jr = "jobs/{}/actions?os=esxi".format(agent_state.job.Uuid)
         ja_list = agent_state.client.get(resource=jr)
         logger.debug("Successfully retrieved {} job actions for job {}".format(
             len(ja_list),
@@ -105,6 +105,11 @@ class RunTask(BaseState):
             agent_state.reboot = False
             agent_state.incomplete = False
             agent_state.failed = False
+            if 'OS' in action.Meta:
+                if 'esxi' not in action.Meta['OS']:
+                    logger.debug("Found non ESXi OS. Skipping JobAction.")
+                    continue
+
             if action.Path != "":
                 logger.debug("Attempting to add a file to the file system.")
                 try:

--- a/drpy/test-requires.txt
+++ b/drpy/test-requires.txt
@@ -1,4 +1,4 @@
-pytest
-pytest-cov
+pytest==4.6.3
+pytest-cov==2.7.1
 flake8
 vcrpy


### PR DESCRIPTION
Fixes issue with travis where the wrong version of pytest was being pulled in
Enhancement moves logging configuration into config file
Enhancement adds filter to runtask to ensure only tasks meant for esxi should be executed.
Document the conf file with logging example in Readme

Signed-off-by: Michael Rice <michael@michaelrice.org>