### PR TITLE
fix(config): never_update_token to true

### DIFF
--- a/drpy/src/drpy/models/config.py
+++ b/drpy/src/drpy/models/config.py
@@ -58,7 +58,7 @@ def parse(conf_file=None):
             mw = conf_dict.get("machine_wait", "wait=10m")
             dur = conf_dict.get("duration", "60")
             las = datetime.datetime.now()
-            up_tok = conf_dict.get("never_update_token", False)
+            up_tok = conf_dict.get("never_update_token", True)
             return Config(
                 endpoint=ep,
                 token=tkn,

--- a/drpy/tests/models/test_config.py
+++ b/drpy/tests/models/test_config.py
@@ -23,7 +23,7 @@ def test_asdict():
         'machine_wait': 'wait=10m',
         'duration': '60',
         'last_updated': None,
-        'never_update_token': False
+        'never_update_token': True
     }
     assert conf_dict == expected
 


### PR DESCRIPTION
Sets the never_update_token to True by default to work around crashing after token update.

Signed-off-by: Michael Rice <michael@michaelrice.org>